### PR TITLE
Inital app construction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,6 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore
+
+# Local data files
+data/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,29 @@
 # visa_atlas
-Reinvent the wheel to check H1b/PERM sponsorships.
+Streamlit MVP for exploring U.S. Labor Condition Application data from local parquet files or a Hugging Face dataset repo.
+
+## Inspiration
+
+This project was inspired by [`lca-analysis`](https://github.com/lansetaowa/lca-analysis/tree/main). Thanks to the author for publishing that work openly.
+
+This project may look like reinventing the wheel, but part of the goal is to provide an ads-free, open source, local-first version that is easy to inspect and extend.
+
+## Project structure
+
+```text
+app.py
+main.py
+tools/
+  xlsx_to_parquet.py
+src/
+  data_loader.py
+  filters.py
+  queries.py
+  charts.py
+  utils.py
+data/
+requirements.txt
+README.md
+```
 
 ## Setup
 
@@ -7,14 +31,77 @@ Reinvent the wheel to check H1b/PERM sponsorships.
 uv sync
 ```
 
-## Run the app
+Or with `pip`:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Add data
+
+Place one or more `.parquet` files under [`data/`](/Users/shihaoqiu/Documents/GitHub/visa_atlas/data).
+
+Or point the app at a Hugging Face dataset repo from the sidebar. By default the app uses local files, but you can switch to `Hugging Face` and enter:
+
+- Dataset repo: `HarryQiuSH/LCA2226`
+- Parquet pattern: `*.parquet`
+
+You can also preconfigure those defaults with:
+
+```bash
+export HF_DATASET_REPO=HarryQiuSH/LCA2226
+export HF_PARQUET_PATTERN='*.parquet'
+```
+
+If your source files are Excel workbooks, convert them first:
+
+```bash
+uv run python tools/xlsx_to_parquet.py
+```
+
+To convert every sheet in each workbook:
+
+```bash
+uv run python tools/xlsx_to_parquet.py --all-sheets
+```
+
+The app inspects parquet schemas, normalizes column names to lowercase snake_case, and maps common LCA field variants such as employer, job title, work location, submit date, start date, wage, and case status.
+
+## Run
+
+```bash
+uv run streamlit run app.py
+```
+
+Compatibility entrypoint:
 
 ```bash
 uv run streamlit run main.py
 ```
+
+## Notes
+
+- DuckDB queries parquet files directly; filtered tables and aggregations are pushed down into SQL where possible.
+- Wage metrics use the first supported wage-like column detected, which may mix units across source files.
+- Missing expected columns do not crash the app; unsupported filters and charts are disabled with warnings.
 
 ## Lint
 
 ```bash
 uv run ruff check .
 ```
+
+## Appendix
+
+Stage two is planned to add PERM data tracking for green card applicants, so the app can evolve from LCA exploration into a broader employment-based immigration tracking tool.
+
+What you can usually analyze from public PERM disclosure data:
+
+- Case metadata: case number or public ID style fields, filing or received dates, decision dates, and status
+- Employer info: employer name, city, state, ZIP, with FEIN often excluded from public disclosure
+- Job info: job title, SOC or occupation code, worksite location, and full-time flag
+- Wage info: offered wage or wage range, plus wage unit such as hourly or yearly
+- Recruitment and legal process fields: selected recruitment or program-form fields depending on filing year and form version
+- Decision outcomes: certified, denied, and withdrawn trends, plus processing timing
+
+Collaborators are welcome if you want to help extend the project toward PERM support, better analytics, or broader employment-based immigration data tooling.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import streamlit as st
+
+from src.charts import (
+    build_bar_chart,
+    build_salary_histogram,
+    build_trend_chart,
+)
+from src.data_loader import (
+    DataSourceError,
+    discover_data_source,
+    get_filter_bounds,
+    get_source_status,
+)
+from src.filters import FilterState, build_sidebar_filters, reset_filters
+from src.queries import (
+    get_export_frame,
+    get_filtered_record_count,
+    get_kpi_summary,
+    get_results_table,
+    get_salary_distribution,
+    get_time_trend,
+    get_top_categories,
+)
+from src.utils import format_currency, format_number
+
+DATA_DIR = Path("data")
+DEFAULT_TABLE_LIMIT = 500
+DEFAULT_HF_REPO = os.getenv("HF_DATASET_REPO", "HarryQiuSH/LCA2226")
+DEFAULT_HF_PATTERN = os.getenv("HF_PARQUET_PATTERN", "*.parquet")
+TOP_N = 10
+
+
+def render_error_state(message: str) -> None:
+    st.error(message)
+    st.stop()
+
+
+def render_data_loading_status(source_info) -> None:
+    """Render a visible data-loading status block for the active source."""
+    if source_info.source_kind == "huggingface":
+        st.info(
+            "Remote data source active.\n\n"
+            f"- Source: {source_info.source_label}\n"
+            f"- DuckDB path: `{source_info.parquet_files[0]}`\n"
+            "- Queries are reading parquet remotely from Hugging Face."
+        )
+    else:
+        st.caption(f"Using local parquet files from `{DATA_DIR}`.")
+
+
+def render_kpis(filters: FilterState, total_records: int, source_info) -> None:
+    unfiltered_total = get_filtered_record_count(source_info, FilterState())
+    summary = get_kpi_summary(source_info, filters)
+
+    delta_value = total_records - unfiltered_total
+    delta_label = f"{delta_value:+,} vs all records" if unfiltered_total else None
+
+    top_dimension = "Top location"
+    top_value = summary.top_location
+    if not top_value:
+        top_dimension = "Top job title"
+        top_value = summary.top_job_title
+
+    col1, col2, col3, col4 = st.columns(4)
+    col1.metric("Matching cases", format_number(summary.total_cases), delta=delta_label)
+    col2.metric("Distinct employers", format_number(summary.distinct_employers))
+    col3.metric("Median offered wage", format_currency(summary.median_wage))
+    col4.metric(top_dimension, top_value or "N/A")
+
+
+def render_analytics(source_info, filters: FilterState) -> None:
+    st.subheader("Analytics")
+    if st.button("Reset all filters", key="reset_filters_top"):
+        reset_filters()
+        st.rerun()
+
+    trend_df = get_time_trend(source_info, filters)
+    top_employers_df = get_top_categories(source_info, filters, "employer_name", TOP_N)
+    top_titles_df = get_top_categories(source_info, filters, "job_title", TOP_N)
+    top_locations_df = get_top_categories(source_info, filters, "work_location", TOP_N)
+    salary_df = get_salary_distribution(source_info, filters)
+
+    fig = build_trend_chart(trend_df)
+    if fig is None:
+        st.info("Submit date data is unavailable for the filings trend.")
+    else:
+        st.plotly_chart(fig, use_container_width=True)
+
+    fig = build_bar_chart(top_employers_df, title="Top employers", x="label", y="case_count")
+    if fig is None:
+        st.info("Employer data is unavailable for ranking charts.")
+    else:
+        st.plotly_chart(fig, use_container_width=True)
+
+    fig = build_bar_chart(top_titles_df, title="Top job titles", x="label", y="case_count")
+    if fig is None:
+        st.info("Job title data is unavailable for ranking charts.")
+    else:
+        st.plotly_chart(fig, use_container_width=True)
+
+    fig = build_bar_chart(top_locations_df, title="Top locations", x="label", y="case_count")
+    if fig is None:
+        st.info("Location data is unavailable for ranking charts.")
+    else:
+        st.plotly_chart(fig, use_container_width=True)
+
+    salary_fig = build_salary_histogram(salary_df)
+    if salary_fig is None:
+        st.info("Salary distribution is unavailable because no supported wage column was detected.")
+    else:
+        st.plotly_chart(salary_fig, use_container_width=True)
+
+
+def render_results(source_info, filters: FilterState, total_records: int) -> None:
+    st.subheader("Detailed records")
+
+    if total_records == 0:
+        st.info("No records match the current filters.")
+        return
+
+    result_limit = st.number_input(
+        "Rows to display",
+        min_value=100,
+        max_value=5000,
+        value=DEFAULT_TABLE_LIMIT,
+        step=100,
+    )
+
+    results_df = get_results_table(source_info, filters, limit=int(result_limit))
+    if results_df.empty:
+        st.info("No rows are available to display.")
+        return
+
+    st.dataframe(results_df, use_container_width=True, hide_index=True)
+
+    export_df = get_export_frame(source_info, filters)
+    st.download_button(
+        "Download filtered CSV",
+        data=export_df.to_csv(index=False).encode("utf-8"),
+        file_name="lca_filtered_results.csv",
+        mime="text/csv",
+    )
+
+
+def build_data_source_config() -> tuple[str, str, str]:
+    """Render source-selection controls and return the chosen configuration."""
+    with st.sidebar:
+        st.header("Data source")
+        source_option = st.radio(
+            "Source",
+            options=("Local data/", "Hugging Face"),
+            key="data_source_kind",
+        )
+
+        if source_option == "Hugging Face":
+            hf_repo_id = st.text_input(
+                "Dataset repo",
+                value=DEFAULT_HF_REPO,
+                key="hf_dataset_repo",
+                help="Example: HarryQiuSH/LCA2226",
+            )
+            hf_parquet_pattern = st.text_input(
+                "Parquet pattern",
+                value=DEFAULT_HF_PATTERN,
+                key="hf_parquet_pattern",
+                help="Example: *.parquet or data/*.parquet",
+            )
+            return "huggingface", hf_repo_id.strip(), hf_parquet_pattern.strip()
+
+    return "local", "", "*.parquet"
+
+
+def main() -> None:
+    st.set_page_config(page_title="Visa Atlas", page_icon=":material/travel_explore:", layout="wide")
+
+    st.title("Visa Atlas")
+    st.caption("Explore U.S. Labor Condition Application filings with SQL-backed search and lightweight analytics.")
+
+    source_kind, hf_repo_id, hf_parquet_pattern = build_data_source_config()
+
+    try:
+        source_info = discover_data_source(
+            DATA_DIR,
+            source_kind=source_kind,
+            hf_repo_id=hf_repo_id,
+            hf_parquet_pattern=hf_parquet_pattern,
+        )
+    except DataSourceError as exc:
+        render_error_state(str(exc))
+
+    status = get_source_status(source_info)
+    status_type = st.success if status.ok else st.warning
+    status_type(status.message)
+    render_data_loading_status(source_info)
+
+    st.write(
+        "Data is read with DuckDB from either local parquet files under `data/` or a Hugging Face dataset repo. "
+        "Wage metrics use the first supported wage-style column detected, so totals are useful for exploration "
+        "but may mix units if the source data does."
+    )
+
+    if source_info.missing_recommended:
+        st.warning(
+            "Some expected columns were not detected: "
+            + ", ".join(source_info.missing_recommended)
+            + ". The app will hide unsupported metrics and filters."
+        )
+
+    filter_bounds = get_filter_bounds(source_info)
+    filters = build_sidebar_filters(source_info, filter_bounds)
+    matching_count = get_filtered_record_count(source_info, filters)
+
+    st.caption(f"Matching records after filters: {format_number(matching_count)}")
+
+    render_kpis(filters, matching_count, source_info)
+    render_analytics(source_info, filters)
+    render_results(source_info, filters, matching_count)
+
+    st.caption(
+        "Date parsing uses DuckDB `TRY_CAST`, so malformed date values are ignored instead of crashing the app."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/main.py
+++ b/main.py
@@ -1,25 +1,4 @@
-import streamlit as st
-
-
-def main() -> None:
-    st.set_page_config(page_title="Visa Atlas", page_icon="🌍", layout="wide")
-    st.title("Visa Atlas")
-    st.caption("Reinvent the wheel to check H1B/PERM sponsorships.")
-
-    st.write(
-        "This is the initial Streamlit app scaffold. "
-        "Use it as the starting point for search, filters, and sponsorship insights."
-    )
-
-    st.subheader("Next steps")
-    st.markdown(
-        """
-        - Connect your data source.
-        - Add employer and visa filters.
-        - Visualize sponsorship trends.
-        """
-    )
-
+from app import main
 
 if __name__ == "__main__":
     main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,11 @@ description = "Streamlit app for exploring visa sponsorship data."
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
+    "duckdb>=1.2.0",
+    "openpyxl>=3.1.0",
+    "pandas>=2.2.0",
+    "plotly>=6.0.0",
+    "pyarrow>=19.0.0",
     "streamlit>=1.43.0",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+streamlit>=1.43.0
+duckdb>=1.2.0
+openpyxl>=3.1.0
+pandas>=2.2.0
+plotly>=6.0.0
+pyarrow>=19.0.0

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""Visa Atlas application package."""

--- a/src/charts.py
+++ b/src/charts.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import plotly.express as px
+import plotly.graph_objects as go
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+
+def build_trend_chart(df: pd.DataFrame) -> go.Figure | None:
+    """Create a monthly filings trend chart."""
+    if df.empty:
+        return None
+    figure = px.line(
+        df,
+        x="filing_month",
+        y="case_count",
+        markers=True,
+        title="Filings trend over time",
+    )
+    figure.update_layout(margin={"l": 16, "r": 16, "t": 48, "b": 16}, xaxis_title="", yaxis_title="Cases")
+    return figure
+
+
+def build_bar_chart(df: pd.DataFrame, title: str, x: str, y: str) -> go.Figure | None:
+    """Create a horizontal ranking bar chart."""
+    if df.empty:
+        return None
+    chart_df = df.sort_values(y, ascending=True)
+    figure = px.bar(chart_df, x=y, y=x, orientation="h", title=title)
+    figure.update_layout(margin={"l": 16, "r": 16, "t": 48, "b": 16}, xaxis_title="Cases", yaxis_title="")
+    return figure
+
+
+def build_salary_histogram(df: pd.DataFrame) -> go.Figure | None:
+    """Create a wage distribution chart when numeric wage data exists."""
+    if df.empty or "wage" not in df.columns:
+        return None
+    figure = px.histogram(df, x="wage", nbins=30, title="Salary distribution")
+    figure.update_layout(margin={"l": 16, "r": 16, "t": 48, "b": 16}, xaxis_title="Wage", yaxis_title="Records")
+    return figure

--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -1,0 +1,318 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import duckdb
+import streamlit as st
+
+from src.utils import make_unique_names, normalize_column_name, quote_identifier, quote_literal
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+CANONICAL_ALIASES: dict[str, tuple[str, ...]] = {
+    "employer_name": (
+        "employer_name",
+        "employer",
+        "employer_business_name",
+        "petitioner_name",
+        "employer_full_name",
+    ),
+    "job_title": (
+        "job_title",
+        "soc_title",
+        "position_title",
+        "job_name",
+        "occupation_title",
+    ),
+    "work_location": (
+        "work_location",
+        "worksite_city",
+        "worksite_state",
+        "worksite",
+        "worksite_location",
+        "job_location",
+        "primary_worksite",
+        "employment_location",
+        "city_state",
+    ),
+    "case_submit_date": (
+        "case_submit_date",
+        "submitted_date",
+        "submission_date",
+        "case_received_date",
+        "received_date",
+        "lca_case_submit_date",
+        "decision_date",
+    ),
+    "employment_start_date": (
+        "employment_start_date",
+        "begin_date",
+        "start_date",
+        "employment_begin_date",
+        "lca_case_start_date",
+    ),
+    "wage": (
+        "wage",
+        "wage_rate_of_pay_from",
+        "wage_rate_of_pay_to",
+        "wage_rate",
+        "wage_from",
+        "offered_wage",
+        "offered_wage_from",
+        "prevailing_wage",
+        "pw_wage_level_1",
+        "salary",
+        "annual_salary",
+        "base_salary",
+    ),
+    "case_status": (
+        "case_status",
+        "status",
+        "application_status",
+        "decision_status",
+    ),
+}
+
+RECOMMENDED_COLUMNS = (
+    "employer_name",
+    "job_title",
+    "work_location",
+    "case_submit_date",
+    "employment_start_date",
+    "wage",
+    "case_status",
+)
+
+
+class DataSourceError(RuntimeError):
+    """Raised when the parquet-backed source cannot be used."""
+
+
+@dataclass(frozen=True)
+class DataSourceInfo:
+    source_kind: str
+    source_label: str
+    parquet_files: tuple[str, ...]
+    table_sql: str
+    normalized_columns: tuple[str, ...]
+    canonical_map: dict[str, str]
+    missing_recommended: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class SourceStatus:
+    ok: bool
+    message: str
+
+
+@dataclass(frozen=True)
+class FilterBounds:
+    submit_date_min: object | None
+    submit_date_max: object | None
+    start_date_min: object | None
+    start_date_max: object | None
+    wage_min: float | None
+    wage_max: float | None
+
+
+@st.cache_resource(show_spinner=False)
+def get_connection() -> duckdb.DuckDBPyConnection:
+    """Create a reusable in-memory DuckDB connection."""
+    connection = duckdb.connect(database=":memory:")
+    connection.execute("PRAGMA threads=4")
+    return connection
+
+
+def discover_parquet_files(data_dir: Path) -> list[Path]:
+    """Return all parquet files found under the configured data directory."""
+    if not data_dir.exists():
+        return []
+    return sorted(data_dir.rglob("*.parquet"))
+
+
+def _build_local_source_sql(parquet_files: tuple[str, ...]) -> str:
+    file_literals = ", ".join(quote_literal(file_path) for file_path in parquet_files)
+    return f"read_parquet([{file_literals}], union_by_name=true, filename=true)"  # noqa: S608
+
+
+def build_hf_source_path(repo_id: str, parquet_pattern: str) -> str:
+    """Return the DuckDB hf:// path for a dataset repo and parquet glob."""
+    repo_path = repo_id.strip().strip("/")
+    pattern_path = parquet_pattern.strip().lstrip("/")
+    return f"hf://datasets/{repo_path}/{pattern_path}"
+
+
+def _build_table_sql(source_sql: str) -> str:
+    conn = get_connection()
+    describe_sql = f"DESCRIBE SELECT * FROM {source_sql}"  # noqa: S608
+    raw_columns = conn.execute(describe_sql).df()["column_name"].tolist()
+
+    normalized_names = make_unique_names(normalize_column_name(column) for column in raw_columns)
+    select_parts = [
+        f"{quote_identifier(original)} AS {quote_identifier(normalized)}"
+        for original, normalized in zip(raw_columns, normalized_names, strict=True)
+    ]
+    return f"SELECT {', '.join(select_parts)} FROM {source_sql}"  # noqa: S608
+
+
+@st.cache_data(show_spinner=False)
+def discover_data_source(
+    data_dir: Path,
+    source_kind: str = "local",
+    hf_repo_id: str = "",
+    hf_parquet_pattern: str = "*.parquet",
+) -> DataSourceInfo:
+    """Inspect parquet files and return the normalized source configuration."""
+    if source_kind == "huggingface":
+        repo_id = hf_repo_id.strip()
+        if not repo_id:
+            raise DataSourceError("Enter a Hugging Face dataset repo ID such as `HarryQiuSH/LCA2226`.")
+        source_path = build_hf_source_path(repo_id, hf_parquet_pattern)
+        parquet_files = (source_path,)
+        source_label = f"Hugging Face dataset `{repo_id}` ({hf_parquet_pattern})"
+        source_sql = f"read_parquet({quote_literal(source_path)}, union_by_name=true, filename=true)"  # noqa: S608
+    else:
+        parquet_files = tuple(str(path) for path in discover_parquet_files(data_dir))
+        if not parquet_files:
+            raise DataSourceError("No parquet files were found under `data/`. Add one or more `.parquet` files and rerun the app.")
+        source_label = f"Local data directory `{data_dir}`"
+        source_sql = _build_local_source_sql(parquet_files)
+
+    try:
+        table_sql = _build_table_sql(source_sql)
+    except duckdb.Error as exc:
+        if source_kind == "huggingface":
+            raise DataSourceError(
+                "Unable to read parquet files from Hugging Face. Confirm the repo ID, file pattern, network access, "
+                "and that the dataset is public or configured for DuckDB access."
+            ) from exc
+        raise DataSourceError("Unable to inspect local parquet files. Check that the files are readable and valid.") from exc
+
+    conn = get_connection()
+    normalized_columns = tuple(
+        conn.execute(f"DESCRIBE SELECT * FROM ({table_sql}) AS src").df()["column_name"].tolist()  # noqa: S608
+    )
+
+    canonical_map: dict[str, str] = {}
+    for canonical_name, aliases in CANONICAL_ALIASES.items():
+        for candidate in aliases:
+            if candidate in normalized_columns:
+                canonical_map[canonical_name] = candidate
+                break
+
+    missing_recommended = tuple(canonical_name for canonical_name in RECOMMENDED_COLUMNS if canonical_name not in canonical_map)
+
+    return DataSourceInfo(
+        source_kind=source_kind,
+        source_label=source_label,
+        parquet_files=parquet_files,
+        table_sql=table_sql,
+        normalized_columns=normalized_columns,
+        canonical_map=canonical_map,
+        missing_recommended=missing_recommended,
+    )
+
+
+def get_source_status(source_info: DataSourceInfo) -> SourceStatus:
+    """Build a concise status message for the current data source."""
+    file_count = len(source_info.parquet_files)
+    column_count = len(source_info.normalized_columns)
+    message = f"Data source loaded: {source_info.source_label}. {file_count} source path(s), {column_count} normalized column(s)."
+    return SourceStatus(ok=file_count > 0, message=message)
+
+
+def get_canonical_column(source_info: DataSourceInfo, canonical_name: str) -> str | None:
+    """Resolve a canonical name to the normalized column present in the source."""
+    return source_info.canonical_map.get(canonical_name)
+
+
+def get_date_expr(source_info: DataSourceInfo, canonical_name: str) -> str | None:
+    """Return a tolerant date expression for the requested canonical field."""
+    column = get_canonical_column(source_info, canonical_name)
+    if not column:
+        return None
+    return f"TRY_CAST({quote_identifier(column)} AS DATE)"
+
+
+def get_location_expr(source_info: DataSourceInfo) -> str | None:
+    """Return a best-effort location expression, preferring city plus state."""
+    city_column = get_canonical_column(source_info, "work_location")
+    state_column = get_canonical_column(source_info, "worksite_state")
+
+    if city_column and state_column:
+        city_expr = quote_identifier(city_column)
+        state_expr = quote_identifier(state_column)
+        return (
+            "CASE "
+            f"WHEN {city_expr} IS NULL AND {state_expr} IS NULL THEN NULL "
+            f"WHEN {state_expr} IS NULL OR trim(CAST({state_expr} AS VARCHAR)) = '' THEN CAST({city_expr} AS VARCHAR) "
+            f"WHEN {city_expr} IS NULL OR trim(CAST({city_expr} AS VARCHAR)) = '' THEN CAST({state_expr} AS VARCHAR) "
+            f"ELSE CAST({city_expr} AS VARCHAR) || ', ' || CAST({state_expr} AS VARCHAR) END"
+        )
+
+    if city_column:
+        return quote_identifier(city_column)
+    if state_column:
+        return quote_identifier(state_column)
+    return None
+
+
+def get_numeric_expr(source_info: DataSourceInfo, canonical_name: str) -> str | None:
+    """Return a tolerant numeric expression for salary-like fields."""
+    column = get_canonical_column(source_info, canonical_name)
+    if not column:
+        return None
+    return "TRY_CAST(" f"regexp_replace(CAST({quote_identifier(column)} AS VARCHAR), '[^0-9.\\-]', '', 'g')" " AS DOUBLE)"
+
+
+@st.cache_data(show_spinner=False)
+def get_filter_bounds(source_info: DataSourceInfo) -> FilterBounds:
+    """Calculate filter defaults without scanning the full dataset into pandas."""
+    conn = get_connection()
+    submit_expr = get_date_expr(source_info, "case_submit_date")
+    start_expr = get_date_expr(source_info, "employment_start_date")
+    wage_expr = get_numeric_expr(source_info, "wage")
+
+    queries: list[str] = []
+    if submit_expr:
+        queries.extend(
+            [
+                f"(SELECT MIN({submit_expr}) FROM ({source_info.table_sql}) AS src) AS submit_date_min",  # noqa: S608
+                f"(SELECT MAX({submit_expr}) FROM ({source_info.table_sql}) AS src) AS submit_date_max",  # noqa: S608
+            ]
+        )
+    else:
+        queries.extend(["NULL AS submit_date_min", "NULL AS submit_date_max"])
+
+    if start_expr:
+        queries.extend(
+            [
+                f"(SELECT MIN({start_expr}) FROM ({source_info.table_sql}) AS src) AS start_date_min",  # noqa: S608
+                f"(SELECT MAX({start_expr}) FROM ({source_info.table_sql}) AS src) AS start_date_max",  # noqa: S608
+            ]
+        )
+    else:
+        queries.extend(["NULL AS start_date_min", "NULL AS start_date_max"])
+
+    if wage_expr:
+        queries.extend(
+            [
+                f"(SELECT MIN({wage_expr}) FROM ({source_info.table_sql}) AS src WHERE {wage_expr} IS NOT NULL) AS wage_min",  # noqa: S608
+                f"(SELECT MAX({wage_expr}) FROM ({source_info.table_sql}) AS src WHERE {wage_expr} IS NOT NULL) AS wage_max",  # noqa: S608
+            ]
+        )
+    else:
+        queries.extend(["NULL AS wage_min", "NULL AS wage_max"])
+
+    row = conn.execute(f"SELECT {', '.join(queries)}").fetchone()  # noqa: S608
+    return FilterBounds(
+        submit_date_min=row[0],
+        submit_date_max=row[1],
+        start_date_min=row[2],
+        start_date_max=row[3],
+        wage_min=row[4],
+        wage_max=row[5],
+    )

--- a/src/filters.py
+++ b/src/filters.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import streamlit as st
+
+from src.data_loader import DataSourceInfo, FilterBounds, get_canonical_column
+from src.queries import get_distinct_values, get_matching_values
+from src.utils import coerce_date
+
+if TYPE_CHECKING:
+    from datetime import date
+
+
+FILTER_KEYS = (
+    "filter_keyword",
+    "filter_employer",
+    "filter_job_title",
+    "filter_location",
+    "filter_case_status",
+    "filter_submit_date_range",
+    "filter_start_date_range",
+    "filter_salary_min",
+    "filter_salary_max",
+)
+
+
+@dataclass(frozen=True)
+class FilterState:
+    keyword: str = ""
+    employer_name: str = ""
+    job_title: str = ""
+    work_location: str = ""
+    case_status: tuple[str, ...] = ()
+    submit_date_start: date | None = None
+    submit_date_end: date | None = None
+    employment_start_date_start: date | None = None
+    employment_start_date_end: date | None = None
+    salary_min: float | None = None
+    salary_max: float | None = None
+
+
+def reset_filters() -> None:
+    for key in FILTER_KEYS:
+        if key in st.session_state:
+            del st.session_state[key]
+
+
+def _date_range_widget(
+    label: str,
+    key: str,
+    start: object | None,
+    end: object | None,
+    disabled: bool,
+) -> tuple[date | None, date | None]:
+    if disabled or not start or not end:
+        st.date_input(label, value=(), key=key, disabled=True)
+        return None, None
+
+    selection = st.date_input(
+        label,
+        value=(coerce_date(start), coerce_date(end)),
+        key=key,
+    )
+    if isinstance(selection, tuple) and len(selection) == 2:
+        return coerce_date(selection[0]), coerce_date(selection[1])
+    return None, None
+
+
+def build_sidebar_filters(source_info: DataSourceInfo, bounds: FilterBounds) -> FilterState:
+    """Render the sidebar filter controls and return the selected state."""
+    with st.sidebar:
+        st.header("Search filters")
+        if st.button("Reset filters", use_container_width=True):
+            reset_filters()
+            st.rerun()
+
+        keyword = st.text_input(
+            "Keyword search",
+            key="filter_keyword",
+            help="Search across employer, job title, and location fields when available.",
+        )
+
+        employer_name = st.text_input(
+            "Employer name",
+            key="filter_employer",
+            disabled=get_canonical_column(source_info, "employer_name") is None,
+        )
+        if employer_name.strip():
+            employer_matches = get_matching_values(source_info, "employer_name", employer_name)
+            if employer_matches:
+                st.caption("Employer matches: " + " | ".join(employer_matches))
+        job_title = st.text_input(
+            "Job title",
+            key="filter_job_title",
+            disabled=get_canonical_column(source_info, "job_title") is None,
+        )
+        if job_title.strip():
+            title_matches = get_matching_values(source_info, "job_title", job_title)
+            if title_matches:
+                st.caption("Job title matches: " + " | ".join(title_matches))
+        work_location = st.text_input(
+            "Work location",
+            key="filter_location",
+            disabled=get_canonical_column(source_info, "work_location") is None,
+        )
+        if work_location.strip():
+            location_matches = get_matching_values(source_info, "work_location", work_location)
+            if location_matches:
+                st.caption("Location matches: " + " | ".join(location_matches))
+        if get_canonical_column(source_info, "case_status") is None:
+            st.text_input("Case status", key="filter_case_status", disabled=True)
+            case_status: tuple[str, ...] = ()
+        else:
+            case_status = tuple(
+                st.multiselect(
+                    "Case status",
+                    options=get_distinct_values(source_info, "case_status", limit=20),
+                    key="filter_case_status",
+                )
+            )
+
+        submit_start, submit_end = _date_range_widget(
+            "Case submit date range",
+            "filter_submit_date_range",
+            bounds.submit_date_min,
+            bounds.submit_date_max,
+            disabled=get_canonical_column(source_info, "case_submit_date") is None,
+        )
+        start_start, start_end = _date_range_widget(
+            "Employment start date range",
+            "filter_start_date_range",
+            bounds.start_date_min,
+            bounds.start_date_max,
+            disabled=get_canonical_column(source_info, "employment_start_date") is None,
+        )
+
+        salary_enabled = get_canonical_column(source_info, "wage") is not None
+        salary_min = st.number_input(
+            "Minimum salary",
+            key="filter_salary_min",
+            min_value=float(bounds.wage_min) if bounds.wage_min is not None else 0.0,
+            value=float(bounds.wage_min) if salary_enabled and bounds.wage_min is not None else 0.0,
+            step=1000.0,
+            disabled=not salary_enabled,
+        )
+        salary_max = st.number_input(
+            "Maximum salary",
+            key="filter_salary_max",
+            min_value=float(bounds.wage_min) if bounds.wage_min is not None else 0.0,
+            value=float(bounds.wage_max) if salary_enabled and bounds.wage_max is not None else 0.0,
+            step=1000.0,
+            disabled=not salary_enabled,
+        )
+
+        if salary_enabled:
+            st.caption(
+                f"Detected salary range: ${bounds.wage_min:,.0f} to ${bounds.wage_max:,.0f}"
+                if bounds.wage_min is not None and bounds.wage_max is not None
+                else "Salary values were detected but bounds could not be inferred."
+            )
+
+    return FilterState(
+        keyword=keyword.strip(),
+        employer_name=employer_name.strip(),
+        job_title=job_title.strip(),
+        work_location=work_location.strip(),
+        case_status=case_status,
+        submit_date_start=submit_start,
+        submit_date_end=submit_end,
+        employment_start_date_start=start_start,
+        employment_start_date_end=start_end,
+        salary_min=salary_min if salary_enabled and salary_min > float(bounds.wage_min or 0) else None,
+        salary_max=salary_max if salary_enabled and bounds.wage_max is not None and salary_max < float(bounds.wage_max) else None,
+    )

--- a/src/queries.py
+++ b/src/queries.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import pandas as pd
+import streamlit as st
+
+from src.data_loader import (
+    DataSourceInfo,
+    get_canonical_column,
+    get_connection,
+    get_date_expr,
+    get_location_expr,
+    get_numeric_expr,
+)
+from src.utils import quote_identifier
+
+if TYPE_CHECKING:
+    from src.filters import FilterState
+
+
+DISPLAY_COLUMNS = (
+    "case_status",
+    "employer_name",
+    "job_title",
+    "work_location",
+    "case_submit_date",
+    "employment_start_date",
+    "wage",
+)
+
+
+@dataclass(frozen=True)
+class KpiSummary:
+    total_cases: int
+    distinct_employers: int
+    median_wage: float | None
+    top_location: str | None
+    top_job_title: str | None
+
+
+def _get_field_expr(source_info: DataSourceInfo, canonical_name: str) -> str | None:
+    if canonical_name in {"case_submit_date", "employment_start_date"}:
+        return get_date_expr(source_info, canonical_name)
+    if canonical_name == "work_location":
+        return get_location_expr(source_info)
+    if canonical_name == "wage":
+        return get_numeric_expr(source_info, canonical_name)
+    column = get_canonical_column(source_info, canonical_name)
+    if not column:
+        return None
+    return quote_identifier(column)
+
+
+def build_where_clause(source_info: DataSourceInfo, filters: FilterState) -> tuple[str, list[object]]:
+    """Translate UI filters into a SQL WHERE clause with bound parameters."""
+    conditions: list[str] = []
+    params: list[object] = []
+
+    def add_contains(canonical_name: str, value: str) -> None:
+        expr = _get_field_expr(source_info, canonical_name)
+        if not expr or not value:
+            return
+        conditions.append(f"{expr} IS NOT NULL AND contains(lower(CAST({expr} AS VARCHAR)), ?)")
+        params.append(value.lower())
+
+    add_contains("employer_name", filters.employer_name)
+    add_contains("job_title", filters.job_title)
+    add_contains("work_location", filters.work_location)
+    if filters.case_status:
+        expr = _get_field_expr(source_info, "case_status")
+        if expr:
+            placeholders = ", ".join("?" for _ in filters.case_status)
+            conditions.append(f"{expr} IN ({placeholders})")
+            params.extend(filters.case_status)
+
+    if filters.keyword:
+        keyword_conditions: list[str] = []
+        for name in ("employer_name", "job_title", "work_location"):
+            expr = _get_field_expr(source_info, name)
+            if expr:
+                keyword_conditions.append(f"contains(lower(CAST({expr} AS VARCHAR)), ?)")
+                params.append(filters.keyword.lower())
+        if keyword_conditions:
+            conditions.append("(" + " OR ".join(keyword_conditions) + ")")
+
+    submit_expr = _get_field_expr(source_info, "case_submit_date")
+    if submit_expr and filters.submit_date_start:
+        conditions.append(f"{submit_expr} >= ?")
+        params.append(filters.submit_date_start)
+    if submit_expr and filters.submit_date_end:
+        conditions.append(f"{submit_expr} <= ?")
+        params.append(filters.submit_date_end)
+
+    start_expr = _get_field_expr(source_info, "employment_start_date")
+    if start_expr and filters.employment_start_date_start:
+        conditions.append(f"{start_expr} >= ?")
+        params.append(filters.employment_start_date_start)
+    if start_expr and filters.employment_start_date_end:
+        conditions.append(f"{start_expr} <= ?")
+        params.append(filters.employment_start_date_end)
+
+    wage_expr = _get_field_expr(source_info, "wage")
+    if wage_expr and filters.salary_min is not None:
+        conditions.append(f"{wage_expr} >= ?")
+        params.append(filters.salary_min)
+    if wage_expr and filters.salary_max is not None:
+        conditions.append(f"{wage_expr} <= ?")
+        params.append(filters.salary_max)
+
+    if not conditions:
+        return "", params
+    return " WHERE " + " AND ".join(conditions), params
+
+
+def _execute_df(sql: str, params: list[object] | None = None) -> pd.DataFrame:
+    conn = get_connection()
+    return conn.execute(sql, params or []).df()
+
+
+@st.cache_data(show_spinner=False)
+def get_filtered_record_count(source_info: DataSourceInfo, filters: FilterState) -> int:
+    where_sql, params = build_where_clause(source_info, filters)
+    sql = f"SELECT COUNT(*) AS record_count FROM ({source_info.table_sql}) AS src{where_sql}"  # noqa: S608
+    row = get_connection().execute(sql, params).fetchone()
+    return int(row[0]) if row else 0
+
+
+@st.cache_data(show_spinner=False)
+def get_distinct_filter_count(source_info: DataSourceInfo, filters: FilterState, canonical_name: str) -> int:
+    expr = _get_field_expr(source_info, canonical_name)
+    if not expr:
+        return 0
+    where_sql, params = build_where_clause(source_info, filters)
+    sql = f"SELECT COUNT(DISTINCT {expr}) FROM ({source_info.table_sql}) AS src{where_sql}"  # noqa: S608
+    row = get_connection().execute(sql, params).fetchone()
+    return int(row[0]) if row else 0
+
+
+@st.cache_data(show_spinner=False)
+def get_distinct_values(source_info: DataSourceInfo, canonical_name: str, limit: int = 100) -> list[str]:
+    expr = _get_field_expr(source_info, canonical_name)
+    if not expr:
+        return []
+    sql = (
+        f"SELECT DISTINCT CAST({expr} AS VARCHAR) AS value "  # noqa: S608
+        f"FROM ({source_info.table_sql}) AS src "  # noqa: S608
+        f"WHERE {expr} IS NOT NULL "  # noqa: S608
+        "ORDER BY 1 "
+        f"LIMIT {int(limit)}"
+    )  # noqa: S608
+    df = _execute_df(sql)
+    return df["value"].tolist()
+
+
+@st.cache_data(show_spinner=False)
+def get_matching_values(
+    source_info: DataSourceInfo, canonical_name: str, query: str, limit: int = 8
+) -> list[str]:
+    expr = _get_field_expr(source_info, canonical_name)
+    if not expr or not query.strip():
+        return []
+    sql = (
+        f"SELECT DISTINCT CAST({expr} AS VARCHAR) AS value "  # noqa: S608
+        f"FROM ({source_info.table_sql}) AS src "  # noqa: S608
+        f"WHERE {expr} IS NOT NULL "  # noqa: S608
+        f"AND contains(lower(CAST({expr} AS VARCHAR)), ?) "  # noqa: S608
+        "ORDER BY 1 "
+        f"LIMIT {int(limit)}"
+    )  # noqa: S608
+    df = _execute_df(sql, [query.lower()])
+    return df["value"].tolist()
+
+
+@st.cache_data(show_spinner=False)
+def get_kpi_summary(source_info: DataSourceInfo, filters: FilterState) -> KpiSummary:
+    where_sql, params = build_where_clause(source_info, filters)
+    wage_expr = _get_field_expr(source_info, "wage")
+    employer_expr = _get_field_expr(source_info, "employer_name")
+    location_expr = _get_field_expr(source_info, "work_location")
+    title_expr = _get_field_expr(source_info, "job_title")
+
+    summary_parts = ["COUNT(*) AS total_cases"]
+    summary_parts.append(f"COUNT(DISTINCT {employer_expr}) AS distinct_employers" if employer_expr else "0 AS distinct_employers")
+    summary_parts.append(f"MEDIAN({wage_expr}) AS median_wage" if wage_expr else "NULL AS median_wage")
+
+    summary_sql = f"SELECT {', '.join(summary_parts)} FROM ({source_info.table_sql}) AS src{where_sql}"  # noqa: S608
+    summary_row = get_connection().execute(summary_sql, params).fetchone()
+
+    def _top_value(expr: str | None) -> str | None:
+        if not expr:
+            return None
+        if where_sql:
+            sql = (  # noqa: S608
+                f"SELECT {expr} AS value FROM ({source_info.table_sql}) AS src"  # noqa: S608
+                f"{where_sql} AND {expr} IS NOT NULL"  # noqa: S608
+            )
+        else:
+            sql = f"SELECT {expr} AS value FROM ({source_info.table_sql}) AS src WHERE {expr} IS NOT NULL"  # noqa: S608
+        sql += " GROUP BY 1 ORDER BY COUNT(*) DESC, value ASC LIMIT 1"  # noqa: S608
+        row = get_connection().execute(sql, params).fetchone()  # noqa: S608
+        return row[0] if row else None
+
+    return KpiSummary(
+        total_cases=int(summary_row[0]) if summary_row else 0,
+        distinct_employers=int(summary_row[1]) if summary_row else 0,
+        median_wage=float(summary_row[2]) if summary_row and summary_row[2] is not None else None,
+        top_location=_top_value(location_expr),
+        top_job_title=_top_value(title_expr),
+    )
+
+
+@st.cache_data(show_spinner=False)
+def get_time_trend(source_info: DataSourceInfo, filters: FilterState) -> pd.DataFrame:
+    date_expr = _get_field_expr(source_info, "case_submit_date")
+    if not date_expr:
+        return pd.DataFrame()
+    where_sql, params = build_where_clause(source_info, filters)
+    extra_filter = f"{where_sql} AND {date_expr} IS NOT NULL" if where_sql else f" WHERE {date_expr} IS NOT NULL"
+    sql = f"""
+        SELECT
+            date_trunc('month', {date_expr}) AS filing_month,
+            COUNT(*) AS case_count
+        FROM ({source_info.table_sql}) AS src
+        {extra_filter}
+        GROUP BY 1
+        ORDER BY 1
+    """
+    return _execute_df(sql, params)
+
+
+@st.cache_data(show_spinner=False)
+def get_top_categories(source_info: DataSourceInfo, filters: FilterState, canonical_name: str, limit: int) -> pd.DataFrame:
+    expr = _get_field_expr(source_info, canonical_name)
+    if not expr:
+        return pd.DataFrame()
+    where_sql, params = build_where_clause(source_info, filters)
+    extra_filter = f"{where_sql} AND {expr} IS NOT NULL" if where_sql else f" WHERE {expr} IS NOT NULL"
+    sql = f"""
+        SELECT
+            CAST({expr} AS VARCHAR) AS label,
+            COUNT(*) AS case_count
+        FROM ({source_info.table_sql}) AS src
+        {extra_filter}
+        GROUP BY 1
+        ORDER BY case_count DESC, label ASC
+        LIMIT {int(limit)}
+    """
+    return _execute_df(sql, params)
+
+
+@st.cache_data(show_spinner=False)
+def get_salary_distribution(source_info: DataSourceInfo, filters: FilterState) -> pd.DataFrame:
+    wage_expr = _get_field_expr(source_info, "wage")
+    if not wage_expr:
+        return pd.DataFrame()
+    where_sql, params = build_where_clause(source_info, filters)
+    extra_filter = f"{where_sql} AND {wage_expr} IS NOT NULL" if where_sql else f" WHERE {wage_expr} IS NOT NULL"
+    sql = (
+        f"SELECT {wage_expr} AS wage "  # noqa: S608
+        f"FROM ({source_info.table_sql}) AS src "  # noqa: S608
+        f"{extra_filter} "  # noqa: S608
+        "LIMIT 10000"
+    )  # noqa: S608
+    return _execute_df(sql, params)
+
+
+@st.cache_data(show_spinner=False)
+def get_results_table(source_info: DataSourceInfo, filters: FilterState, limit: int) -> pd.DataFrame:
+    where_sql, params = build_where_clause(source_info, filters)
+    select_parts: list[str] = []
+
+    for canonical_name in DISPLAY_COLUMNS:
+        expr = _get_field_expr(source_info, canonical_name)
+        if expr:
+            select_parts.append(f"{expr} AS {quote_identifier(canonical_name)}")  # noqa: S608
+
+    if not select_parts:
+        fallback_column = quote_identifier(source_info.normalized_columns[0])
+        select_parts = [fallback_column]
+
+    order_expr = _get_field_expr(source_info, "case_submit_date")
+    if not order_expr:
+        order_expr = _get_field_expr(source_info, "employment_start_date")
+    order_sql = f" ORDER BY {order_expr} DESC NULLS LAST" if order_expr else ""
+
+    sql = (  # noqa: S608
+        f"SELECT {', '.join(select_parts)} FROM ({source_info.table_sql}) AS src"  # noqa: S608
+        f"{where_sql}{order_sql} LIMIT {int(limit)}"  # noqa: S608
+    )
+    df = _execute_df(sql, params)
+
+    for column in ("case_submit_date", "employment_start_date"):
+        if column in df.columns:
+            df[column] = pd.to_datetime(df[column], errors="coerce").dt.date
+    if "wage" in df.columns:
+        df["wage"] = pd.to_numeric(df["wage"], errors="coerce")
+
+    renamed_columns = {
+        "case_status": "Case status",
+        "employer_name": "Employer",
+        "job_title": "Job title",
+        "work_location": "Work location",
+        "case_submit_date": "Case submit date",
+        "employment_start_date": "Employment start date",
+        "wage": "Offered wage",
+    }
+    return df.rename(columns=renamed_columns)
+
+
+@st.cache_data(show_spinner=False)
+def get_export_frame(source_info: DataSourceInfo, filters: FilterState) -> pd.DataFrame:
+    """Return the full filtered result set for CSV export."""
+    where_sql, params = build_where_clause(source_info, filters)
+    select_parts: list[str] = []
+    for canonical_name in DISPLAY_COLUMNS:
+        expr = _get_field_expr(source_info, canonical_name)
+        if expr:
+            select_parts.append(f"{expr} AS {quote_identifier(canonical_name)}")
+    if not select_parts:
+        select_parts = [quote_identifier(column) for column in source_info.normalized_columns[:10]]
+
+    sql = f"SELECT {', '.join(select_parts)} FROM ({source_info.table_sql}) AS src{where_sql}"  # noqa: S608
+    return _execute_df(sql, params)

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import re
+from datetime import date, datetime
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+def normalize_column_name(name: str) -> str:
+    """Convert arbitrary column names to lowercase snake_case."""
+    normalized = re.sub(r"[^0-9a-zA-Z]+", "_", name.strip().lower())
+    normalized = re.sub(r"_+", "_", normalized).strip("_")
+    return normalized or "column"
+
+
+def make_unique_names(names: Iterable[str]) -> list[str]:
+    """Preserve normalized names while resolving collisions deterministically."""
+    counts: dict[str, int] = {}
+    result: list[str] = []
+    for name in names:
+        count = counts.get(name, 0)
+        result_name = name if count == 0 else f"{name}_{count + 1}"
+        counts[name] = count + 1
+        result.append(result_name)
+    return result
+
+
+def quote_identifier(name: str) -> str:
+    """Safely quote a SQL identifier for DuckDB."""
+    return '"' + name.replace('"', '""') + '"'
+
+
+def quote_literal(value: str) -> str:
+    """Safely quote a SQL string literal for DuckDB."""
+    return "'" + value.replace("'", "''") + "'"
+
+
+def coerce_date(value: object) -> date | None:
+    """Convert Streamlit widget values into a Python date when possible."""
+    if value is None:
+        return None
+    if isinstance(value, date):
+        return value
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, pd.Timestamp):
+        return value.date()
+    return None
+
+
+def format_number(value: int | float | None) -> str:
+    """Format counts and numeric KPIs."""
+    if value is None:
+        return "N/A"
+    return f"{value:,.0f}"
+
+
+def format_currency(value: float | None) -> str:
+    """Format wage-like values for display."""
+    if value is None or pd.isna(value):
+        return "N/A"
+    return f"${value:,.0f}"

--- a/tools/xlsx_to_parquet.py
+++ b/tools/xlsx_to_parquet.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import time
+from pathlib import Path
+
+import pandas as pd
+
+DEFAULT_DATA_DIR = Path("data")
+MAX_SUFFIX_LENGTH = 32
+
+
+def log(message: str) -> None:
+    """Print a timestamped progress line."""
+    print(f"[xlsx-to-parquet] {message}")
+
+
+def sanitize_sheet_name(sheet_name: str) -> str:
+    """Create a filesystem-friendly suffix for sheet-derived output names."""
+    value = re.sub(r"[^0-9a-zA-Z]+", "_", sheet_name.strip().lower())
+    return value.strip("_") or "sheet"
+
+
+def condense_sheet_suffix(workbook_path: Path, sheet_name: str) -> str:
+    """Build a short sheet suffix by removing tokens already present in the workbook name."""
+    workbook_tokens = [token for token in sanitize_sheet_name(workbook_path.stem).split("_") if token]
+    sheet_tokens = [token for token in sanitize_sheet_name(sheet_name).split("_") if token]
+
+    while workbook_tokens and sheet_tokens and workbook_tokens[0] == sheet_tokens[0]:
+        workbook_tokens.pop(0)
+        sheet_tokens.pop(0)
+
+    workbook_suffix_tokens = [token for token in sanitize_sheet_name(workbook_path.stem).split("_") if token]
+    while workbook_suffix_tokens and sheet_tokens and workbook_suffix_tokens[-1] == sheet_tokens[-1]:
+        workbook_suffix_tokens.pop()
+        sheet_tokens.pop()
+
+    suffix = "_".join(sheet_tokens) or "sheet"
+    if len(suffix) > MAX_SUFFIX_LENGTH:
+        suffix = suffix[:MAX_SUFFIX_LENGTH].rstrip("_")
+    return suffix or "sheet"
+
+
+def discover_workbooks(data_dir: Path) -> list[Path]:
+    """Return Excel workbooks under the configured data directory."""
+    workbooks = sorted(data_dir.rglob("*.xlsx"))
+    return [path for path in workbooks if not path.name.startswith("~$")]
+
+
+def build_output_path(workbook_path: Path, sheet_name: str | None, all_sheets: bool) -> Path:
+    """Choose the parquet output path for a workbook or workbook sheet."""
+    if all_sheets and sheet_name:
+        condensed_suffix = condense_sheet_suffix(workbook_path, sheet_name)
+        if condensed_suffix in {"", "sheet"}:
+            return workbook_path.with_suffix(".parquet")
+        return workbook_path.with_name(f"{workbook_path.stem}__{condensed_suffix}.parquet")
+    return workbook_path.with_suffix(".parquet")
+
+
+def expected_output_paths(workbook_path: Path, sheet_names: list[str], all_sheets: bool) -> list[Path]:
+    """Return the parquet files expected for a workbook conversion."""
+    if all_sheets:
+        return [build_output_path(workbook_path, sheet_name, all_sheets=True) for sheet_name in sheet_names]
+    return [build_output_path(workbook_path, sheet_names[0], all_sheets=False)]
+
+
+def write_parquet(df: pd.DataFrame, output_path: Path) -> None:
+    """Persist a dataframe to parquet, creating parent directories when needed."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_parquet(output_path, index=False)
+
+
+def find_mixed_object_columns(df: pd.DataFrame) -> list[str]:
+    """Return object columns containing multiple concrete Python value types."""
+    mixed_columns: list[str] = []
+    object_columns = df.select_dtypes(include=["object"]).columns
+
+    for column_name in object_columns:
+        non_null_values = df[column_name].dropna()
+        if non_null_values.empty:
+            continue
+        value_types = {type(value).__name__ for value in non_null_values}
+        if len(value_types) > 1:
+            mixed_columns.append(column_name)
+
+    return mixed_columns
+
+
+def normalize_for_parquet(df: pd.DataFrame) -> tuple[pd.DataFrame, list[str]]:
+    """Coerce mixed-type object columns to string before parquet serialization."""
+    normalized_df = df.copy()
+    mixed_columns = find_mixed_object_columns(normalized_df)
+
+    for column_name in mixed_columns:
+        normalized_df[column_name] = normalized_df[column_name].astype("string")
+
+    return normalized_df, mixed_columns
+
+
+def safe_write_parquet(df: pd.DataFrame, output_path: Path) -> None:
+    """Write parquet after normalizing mixed object columns in pandas."""
+    normalized_df, coerced_columns = normalize_for_parquet(df)
+    if coerced_columns:
+        log("Coercing mixed-type object columns to string: " + ", ".join(coerced_columns))
+
+    try:
+        write_parquet(normalized_df, output_path)
+    except Exception as exc:
+        log(f"Parquet write failed after pandas normalization: {exc}")
+        raise
+
+
+def convert_workbook(workbook_path: Path, all_sheets: bool) -> int:
+    """Convert one workbook into one or more parquet files."""
+    start_time = time.perf_counter()
+    log(f"Reading workbook: {workbook_path}")
+
+    excel_file = pd.ExcelFile(workbook_path, engine="openpyxl")
+    log(f"Discovered sheets: {', '.join(excel_file.sheet_names)}")
+
+    sheet_names = excel_file.sheet_names if all_sheets else [excel_file.sheet_names[0]]
+    if not all_sheets and len(excel_file.sheet_names) > 1:
+        log(f"Multiple sheets detected. Converting only the first sheet: {sheet_names[0]}")
+
+    output_paths = expected_output_paths(workbook_path, sheet_names, all_sheets=all_sheets)
+    if output_paths and all(path.exists() for path in output_paths):
+        log(f"Parquet output already exists for {workbook_path.name}. Removing source workbook.")
+        workbook_path.unlink()
+        return 0
+
+    written_files = 0
+    for sheet_name in sheet_names:
+        sheet_start = time.perf_counter()
+        log(f"Loading sheet '{sheet_name}'")
+        dataframe = pd.read_excel(excel_file, sheet_name=sheet_name, engine="openpyxl")
+        log(f"Loaded {len(dataframe):,} rows x {len(dataframe.columns):,} columns from '{sheet_name}'")
+
+        output_path = build_output_path(workbook_path, sheet_name, all_sheets=all_sheets)
+        log(f"Writing parquet: {output_path}")
+        safe_write_parquet(dataframe, output_path)
+
+        elapsed = time.perf_counter() - sheet_start
+        size_mb = output_path.stat().st_size / (1024 * 1024)
+        log(f"Finished '{sheet_name}' in {elapsed:.2f}s -> {output_path.name} ({size_mb:.2f} MB)")
+        written_files += 1
+
+    total_elapsed = time.perf_counter() - start_time
+    log(f"Removing source workbook: {workbook_path}")
+    workbook_path.unlink()
+    log(f"Workbook complete: {workbook_path.name} in {total_elapsed:.2f}s")
+    return written_files
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments for workbook discovery and conversion behavior."""
+    parser = argparse.ArgumentParser(
+        description="Convert .xlsx files under data/ into parquet files with verbose progress output."
+    )
+    parser.add_argument(
+        "--data-dir",
+        type=Path,
+        default=DEFAULT_DATA_DIR,
+        help="Directory to scan for .xlsx files. Defaults to ./data",
+    )
+    parser.add_argument(
+        "--all-sheets",
+        action="store_true",
+        help="Convert every sheet in each workbook. Output files are suffixed by sheet name.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run workbook discovery and conversion."""
+    args = parse_args()
+    data_dir = args.data_dir.resolve()
+
+    log(f"Using data directory: {data_dir}")
+    if not data_dir.exists():
+        log("Data directory does not exist.")
+        return 1
+
+    workbooks = discover_workbooks(data_dir)
+    if not workbooks:
+        log("No .xlsx files found. Add Excel workbooks under data/ and run again.")
+        return 1
+
+    log(f"Found {len(workbooks)} workbook(s) to convert.")
+    converted_files = 0
+    for workbook_path in workbooks:
+        converted_files += convert_workbook(workbook_path, all_sheets=args.all_sheets)
+
+    log(f"Done. Wrote {converted_files} parquet file(s) from {len(workbooks)} workbook(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -153,6 +153,51 @@ wheels = [
 ]
 
 [[package]]
+name = "duckdb"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/11/e05a7eb73a373d523e45d83c261025e02bc31ebf868e6282c30c4d02cc59/duckdb-1.5.0.tar.gz", hash = "sha256:f974b61b1c375888ee62bc3125c60ac11c4e45e4457dd1bb31a8f8d3cf277edd", size = 17981141, upload-time = "2026-03-09T12:50:26.372Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/0c/0282b10a1c96810606b916b8d58a03f2131bd3ede14d2851f58b0b860e7c/duckdb-1.5.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3298bd17cf0bb5f342fb51a4edc9aadacae882feb2b04161a03eb93271c70c86", size = 30014615, upload-time = "2026-03-09T12:48:54.061Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e8/cbbc920078a794f24f63017fc55c9cbdb17d6fb94d3973f479b2d9f2983d/duckdb-1.5.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:13f94c49ca389731c439524248e05007fb1a86cd26f1e38f706abc261069cd41", size = 15940493, upload-time = "2026-03-09T12:48:57.85Z" },
+    { url = "https://files.pythonhosted.org/packages/31/b6/6cae794d5856259b0060f79d5db71c7fdba043950eaa6a9d72b0bad16095/duckdb-1.5.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ab9d597b1e8668466f1c164d0ea07eaf0ebb516950f5a2e794b0f52c81ff3b16", size = 14194663, upload-time = "2026-03-09T12:49:00.416Z" },
+    { url = "https://files.pythonhosted.org/packages/82/07/aba3887658b93a36ce702dd00ca6a6422de3d14c7ee3a4b4c03ea20a99c0/duckdb-1.5.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a43f8289b11c0b50d13f96ab03210489d37652f3fd7911dc8eab04d61b049da2", size = 19220501, upload-time = "2026-03-09T12:49:03.431Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/a2/723e6df48754e468fa50d7878eb860906c975eafe317c4134a8482ca220e/duckdb-1.5.0-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4f514e796a116c5de070e99974e42d0b8c2e6c303386790e58408c481150d417", size = 21316142, upload-time = "2026-03-09T12:49:06.223Z" },
+    { url = "https://files.pythonhosted.org/packages/03/af/4dcbdf8f2349ed0b054c254ec59bc362ce6ddf603af35f770124c0984686/duckdb-1.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:cf503ba2c753d97c76beb111e74572fef8803265b974af2dca67bba1de4176d2", size = 13043445, upload-time = "2026-03-09T12:49:08.892Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5e/1bb7e75a63bf3dc49bc5a2cd27a65ffeef151f52a32db980983516f2d9f6/duckdb-1.5.0-cp311-cp311-win_arm64.whl", hash = "sha256:a1156e91e4e47f0e7d9c9404e559a1d71b372cd61790a407d65eb26948ae8298", size = 13883145, upload-time = "2026-03-09T12:49:11.566Z" },
+    { url = "https://files.pythonhosted.org/packages/43/73/120e673e48ae25aaf689044c25ef51b0ea1d088563c9a2532612aea18e0a/duckdb-1.5.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9ea988d1d5c8737720d1b2852fd70e4d9e83b1601b8896a1d6d31df5e6afc7dd", size = 30057869, upload-time = "2026-03-09T12:49:14.65Z" },
+    { url = "https://files.pythonhosted.org/packages/21/e9/61143471958d36d3f3e764cb4cd43330be208ddbff1c78d3310b9ee67fe8/duckdb-1.5.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:cb786d5472afc16cc3c7355eb2007172538311d6f0cc6f6a0859e84a60220375", size = 15963092, upload-time = "2026-03-09T12:49:17.478Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/71/76e37c9a599ad89dd944e6cbb3e6a8ad196944a421758e83adea507637b6/duckdb-1.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:dc92b238f4122800a7592e99134124cc9048c50f766c37a0778dd2637f5cbe59", size = 14220562, upload-time = "2026-03-09T12:49:23.518Z" },
+    { url = "https://files.pythonhosted.org/packages/db/b8/de1831656d5d13173e27c79c7259c8b9a7bdc314fdc8920604838ea4c46d/duckdb-1.5.0-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b74cb205c21d3696d8f8b88adca401e1063d6e6f57c1c4f56a243610b086e30", size = 19245329, upload-time = "2026-03-09T12:49:26.307Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/8d/33d349a3bcbd3e9b7b4e904c19d5b97f058c4c20791b89a8d6323bb93dce/duckdb-1.5.0-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6e56c19ffd1ffe3642fa89639e71e2e00ab0cf107b62fe16e88030acaebcbde6", size = 21348041, upload-time = "2026-03-09T12:49:30.283Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ec/591a4cad582fae04bc8f8b4a435eceaaaf3838cf0ca771daae16a3c2995b/duckdb-1.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:86525e565ec0c43420106fd34ba2c739a54c01814d476c7fed3007c9ed6efd86", size = 13053781, upload-time = "2026-03-09T12:49:33.574Z" },
+    { url = "https://files.pythonhosted.org/packages/db/62/42e0a13f9919173bec121c0ff702406e1cdd91d8084c3e0b3412508c3891/duckdb-1.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:5faeebc178c986a7bfa68868a023001137a95a1110bf09b7356442a4eae0f7e7", size = 13862906, upload-time = "2026-03-09T12:49:36.598Z" },
+    { url = "https://files.pythonhosted.org/packages/35/5d/af5501221f42e4e3662c047ecec4dcd0761229fceeba3c67ad4d9d8741df/duckdb-1.5.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:11dd05b827846c87f0ae2f67b9ae1d60985882a7c08ce855379e4a08d5be0e1d", size = 30057396, upload-time = "2026-03-09T12:49:39.95Z" },
+    { url = "https://files.pythonhosted.org/packages/43/bd/a278d73fedbd3783bf9aedb09cad4171fe8e55bd522952a84f6849522eb6/duckdb-1.5.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5ad8d9c91b7c280ab6811f59deff554b845706c20baa28c4e8f80a95690b252b", size = 15962700, upload-time = "2026-03-09T12:49:43.504Z" },
+    { url = "https://files.pythonhosted.org/packages/76/fc/c916e928606946209c20fb50898dabf120241fb528a244e2bd8cde1bd9e2/duckdb-1.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0ee4dabe03ed810d64d93927e0fd18cd137060b81ee75dcaeaaff32cbc816656", size = 14220272, upload-time = "2026-03-09T12:49:46.867Z" },
+    { url = "https://files.pythonhosted.org/packages/53/07/1390e69db922423b2e111e32ed342b3e8fad0a31c144db70681ea1ba4d56/duckdb-1.5.0-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9409ed1184b363ddea239609c5926f5148ee412b8d9e5ffa617718d755d942f6", size = 19244401, upload-time = "2026-03-09T12:49:49.865Z" },
+    { url = "https://files.pythonhosted.org/packages/54/13/b58d718415cde993823a54952ea511d2612302f1d2bc220549d0cef752a4/duckdb-1.5.0-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1df8c4f9c853a45f3ec1e79ed7fe1957a203e5ec893bbbb853e727eb93e0090f", size = 21345827, upload-time = "2026-03-09T12:49:52.977Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/96/4460429651e371eb5ff745a4790e7fa0509c7a58c71fc4f0f893404c9646/duckdb-1.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:9a3d3dfa2d8bc74008ce3ad9564761ae23505a9e4282f6a36df29bd87249620b", size = 13053101, upload-time = "2026-03-09T12:49:56.134Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/54/6d5b805113214b830fa3c267bb3383fb8febaa30760d0162ef59aadb110a/duckdb-1.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:2deebcbafd9d39c04f31ec968f4dd7cee832c021e10d96b32ab0752453e247c8", size = 13865071, upload-time = "2026-03-09T12:49:59.282Z" },
+    { url = "https://files.pythonhosted.org/packages/66/9f/dd806d4e8ecd99006eb240068f34e1054533da1857ad06ac726305cd102d/duckdb-1.5.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:d4b618de670cd2271dd7b3397508c7b3c62d8ea70c592c755643211a6f9154fa", size = 30065704, upload-time = "2026-03-09T12:50:02.671Z" },
+    { url = "https://files.pythonhosted.org/packages/79/c2/7b7b8a5c65d5535c88a513e267b5e6d7a55ab3e9b67e4ddd474454653268/duckdb-1.5.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:065ae50cb185bac4b904287df72e6b4801b3bee2ad85679576dd712b8ba07021", size = 15964883, upload-time = "2026-03-09T12:50:06.343Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c5/9a52a2cdb228b8d8d191a603254364d929274d9cc7d285beada8f7daa712/duckdb-1.5.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6be5e48e287a24d98306ce9dd55093c3b105a8fbd8a2e7a45e13df34bf081985", size = 14221498, upload-time = "2026-03-09T12:50:10.567Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/68/646045cb97982702a8a143dc2e45f3bdcb79fbe2d559a98d74b8c160e5e2/duckdb-1.5.0-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a5ee41a0bf793882f02192ce105b9a113c3e8c505a27c7ef9437d7b756317113", size = 19249787, upload-time = "2026-03-09T12:50:13.524Z" },
+    { url = "https://files.pythonhosted.org/packages/15/1b/5abf0c7f38febb3b4a231c784223fceccfd3f2bfd957699d786f46e41ce6/duckdb-1.5.0-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f8e42aaf3cd217417c5dc9ff522dc3939d18b25a6fe5f846348277e831e6f59c", size = 21351583, upload-time = "2026-03-09T12:50:16.701Z" },
+    { url = "https://files.pythonhosted.org/packages/93/a4/a90f2901cc0a1ce7ca4f0564b8492b9dbfe048a6395b27933d46ae9be473/duckdb-1.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:11ae50aaeda2145b50294ee0247e4f11fb9448b3cc3d2aea1cfc456637dfb977", size = 13575130, upload-time = "2026-03-09T12:50:19.716Z" },
+    { url = "https://files.pythonhosted.org/packages/64/aa/f14dd5e241ec80d9f9d82196ca65e0c53badfc8a7a619d5497c5626657ad/duckdb-1.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:d6d2858c734d1a7e7a1b6e9b8403b3fce26dfefb4e0a2479c420fba6cd36db36", size = 14341879, upload-time = "2026-03-09T12:50:22.347Z" },
+]
+
+[[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
+]
+
+[[package]]
 name = "gitdb"
 version = "4.0.12"
 source = { registry = "https://pypi.org/simple" }
@@ -387,6 +432,18 @@ wheels = [
 ]
 
 [[package]]
+name = "openpyxl"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "et-xmlfile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -534,6 +591,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/00/98/fc53ab36da80b88df0967896b6c4b4cd948a0dc5aa40a754266aa3ae48b3/pillow-12.1.1-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f975aa7ef9684ce7e2c18a3aa8f8e2106ce1e46b94ab713d156b2898811651d3", size = 5313850, upload-time = "2026-02-11T04:23:00.554Z" },
     { url = "https://files.pythonhosted.org/packages/30/02/00fa585abfd9fe9d73e5f6e554dc36cc2b842898cbfc46d70353dae227f8/pillow-12.1.1-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8089c852a56c2966cf18835db62d9b34fef7ba74c726ad943928d494fa7f4735", size = 5963343, upload-time = "2026-02-11T04:23:02.934Z" },
     { url = "https://files.pythonhosted.org/packages/f2/26/c56ce33ca856e358d27fda9676c055395abddb82c35ac0f593877ed4562e/pillow-12.1.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:cb9bb857b2d057c6dfc72ac5f3b44836924ba15721882ef103cecb40d002d80e", size = 7029880, upload-time = "2026-02-11T04:23:04.783Z" },
+]
+
+[[package]]
+name = "plotly"
+version = "6.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "narwhals" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/24/fb/41efe84970cfddefd4ccf025e2cbfafe780004555f583e93dba3dac2cdef/plotly-6.6.0.tar.gz", hash = "sha256:b897f15f3b02028d69f755f236be890ba950d0a42d7dfc619b44e2d8cea8748c", size = 7027956, upload-time = "2026-03-02T21:10:25.321Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/d2/c6e44dba74f17c6216ce1b56044a9b93a929f1c2d5bdaff892512b260f5e/plotly-6.6.0-py3-none-any.whl", hash = "sha256:8d6daf0f87412e0c0bfe72e809d615217ab57cc715899a1e5145135a7800d1d0", size = 9910315, upload-time = "2026-03-02T21:10:18.131Z" },
 ]
 
 [[package]]
@@ -844,6 +914,19 @@ wheels = [
 ]
 
 [[package]]
+name = "streamlit-plotly-events"
+version = "0.0.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "plotly" },
+    { name = "streamlit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/8c/e51c4867cc4d819f8452811199241d0edbcec73621768270ada66153f874/streamlit-plotly-events-0.0.6.tar.gz", hash = "sha256:1fe25dbf0e5d803aeb90253be04d7b395f5bcfdf3c654f96ff3c19424e7f9582", size = 4874598, upload-time = "2021-04-26T23:36:16.973Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/08/51dd5c822e27410f6452c3cfe61f7163fdeb40f4d285f2da6c2b9f88584d/streamlit_plotly_events-0.0.6-py3-none-any.whl", hash = "sha256:e63fbe3c6a0746fdfce20060fc45ba5cd97805505c332b27372dcbd02c2ede29", size = 14802161, upload-time = "2021-04-26T23:36:09.194Z" },
+]
+
+[[package]]
 name = "tenacity"
 version = "9.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -910,7 +993,13 @@ name = "visa-atlas"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "duckdb" },
+    { name = "openpyxl" },
+    { name = "pandas" },
+    { name = "plotly" },
+    { name = "pyarrow" },
     { name = "streamlit" },
+    { name = "streamlit-plotly-events" },
 ]
 
 [package.dev-dependencies]
@@ -919,7 +1008,15 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "streamlit", specifier = ">=1.43.0" }]
+requires-dist = [
+    { name = "duckdb", specifier = ">=1.2.0" },
+    { name = "openpyxl", specifier = ">=3.1.0" },
+    { name = "pandas", specifier = ">=2.2.0" },
+    { name = "plotly", specifier = ">=6.0.0" },
+    { name = "pyarrow", specifier = ">=19.0.0" },
+    { name = "streamlit", specifier = ">=1.43.0" },
+    { name = "streamlit-plotly-events", specifier = ">=0.0.6" },
+]
 
 [package.metadata.requires-dev]
 dev = [{ name = "ruff", specifier = "==0.1.9" }]


### PR DESCRIPTION
## Title

Add Streamlit MVP for LCA exploration with DuckDB, local/Hugging Face parquet support, and schema-tolerant filters

## Summary

This PR adds a production-oriented MVP Streamlit app for exploring U.S. LCA disclosure data.

It introduces a DuckDB-backed query layer over parquet files, a sidebar-driven filter experience, summary KPIs, analytics charts, a filtered results table, and CSV export. The app supports both local parquet files under `data/` and remote parquet reads from a Hugging Face dataset repo.

It also includes a lightweight schema-normalization layer so the app can tolerate common LCA column-name variants instead of assuming one exact source schema.

## Changes

- Add Streamlit app entrypoint in `app.py`
- Add modular app structure under `src/`
- Add DuckDB parquet discovery and schema normalization
- Add combined filters for employer, job title, location, dates, salary, and case status
- Add KPI summary row, trend/ranking charts, results table, and CSV export
- Add support for both local parquet files and Hugging Face dataset parquet sources
- Add Excel-to-parquet conversion utility in `tools/xlsx_to_parquet.py`
- Update dependencies and README documentation

## Notes

- Hugging Face mode currently reads remote parquet files live through DuckDB, so it may be slower than local mode
- Wage metrics use the first supported wage-like column detected, which is useful for exploration but may mix units across source files
- Charts are vertically stacked and do not currently support click-to-filter
- The README now includes attribution to `lca-analysis` and notes a possible stage two for PERM support

## Testing

- `ruff check app.py src`
- `python -m compileall app.py src`
